### PR TITLE
Separate SSL configuration so that it can be disabled more easily

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ target/fake_oidc_server.jar \
    --oidc.users.john.email=john.doe@example.com \
    --oidc.users.john.given_name="John" \
    --oidc.users.john.family_name="Doe"
-```  
+```
 See all the available options in the file src/main/resources/application.yml
+
+To disable SSL entirely you must disable the `ssl` spring profile. In order to do that you must overwrite the active profiles:
+
+```bash
+java -jar -Dspring.profiles.active=default target/fake_oidc_server.jar
+```
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,12 +5,7 @@
 
 server:
   port: 8090
-  ssl:
-    key-store-type: pkcs12
-    # create your own keystore with:
-    #  openssl pkcs12 -export -name "mycert" -inkey key.pem -in cert.pem -certfile chain.pem -out mykeystore.p12
-    key-store: classpath:keystore.p12
-    key-store-password: password
+
 oidc:
   tokenExpirationSeconds: 36000
   users:
@@ -26,3 +21,17 @@ oidc:
       given_name: "Martin"
       family_name: "Kuba"
       email: "makub@ics.muni.cz"
+
+spring.profiles.active: ssl
+
+---
+ 
+spring.config.activate.on-profile : ssl
+
+server:
+  ssl:
+    key-store-type: pkcs12
+    # create your own keystore with:
+    #  openssl pkcs12 -export -name "mycert" -inkey key.pem -in cert.pem -certfile chain.pem -out mykeystore.p12
+    key-store: classpath:keystore.p12
+    key-store-password: password


### PR DESCRIPTION
I had the use case where I need to disable SSL in the server. Maybe others have the same need too. 

**Changes:**
The configuration is splitted into two spring profiles. One is the default, one is for SSL configuration. If SSL is not needed, you can prevent it from loading by overwriting the active profiles. 

**Reasoning:**
As soon the ssl configuration is set, spring will auto configure the tomcat to use SSL. It is very hard to stop spring from doing that because you can't (?) remove system properties via CLI. Just overwriting the properties with empty values isn't enough to stop the auto configuration too. 


Thx for the project.